### PR TITLE
include .Xresources.local on .Xresources

### DIFF
--- a/etc/skel/.Xresources
+++ b/etc/skel/.Xresources
@@ -197,4 +197,6 @@ nedit*XmText.background:            white
 nedit*XmTextField.background:       white
 nedit*XmList.background:            white
 
+#include ".Xresources.local"
+
 !# END OF FILE #################################################################


### PR DESCRIPTION
This change would be consistent with other files of the grml project, such as its `.vimrc` and `.zshrc`.