### PR TITLE
Replace iceweasel with firefox

### DIFF
--- a/etc/skel/.fluxbox/keys
+++ b/etc/skel/.fluxbox/keys
@@ -88,7 +88,7 @@ Control Mod1 a  :ArrangeWindows
 
 # keymappings for programs
 Control Mod1 l :ExecCommand xlock
-Control Mod1 f :ExecCommand iceweasel
+Control Mod1 f :ExecCommand firefox
 
 # screenshot
 Control Shift s :ExecCommand import -window root `date +shot-%Y-%m-%d-%H%M%S.jpg`

--- a/etc/skel/.fluxbox/menu
+++ b/etc/skel/.fluxbox/menu
@@ -1,6 +1,6 @@
 [begin] (Fluxbox) {} <>
     [exec] (xterm) {x-terminal-emulator} <>
-    [exec] (Iceweasel / Firefox) {iceweasel} <>
+    [exec] (Firefox) {firefox} <>
     [exec] (Run ...) {fbrun} <>
     [exec] (configure network) {sudo x-terminal-emulator -T "grml-network" -e /usr/sbin/grml-network} <>
     [exec] (configure and run terminalserver) {grml-exec-wrapper -p grml-terminalserver sudo x-terminal-emulator -T "grml-terminalserver" -e /usr/sbin/grml-terminalserver} <>

--- a/etc/skel/.gtkrc-2.0
+++ b/etc/skel/.gtkrc-2.0
@@ -1,2 +1,0 @@
-# workaround for an iceweasel bug regarding the forward/back button
-gtk-fallback-icon-theme="moblin"


### PR DESCRIPTION
Replace iceweasel with firefox

- Changed the fluxbox shortcut to open firefox
- Changed the fluxbox menu to open firefox
- The workaround for an iceweasel bug regarding the forward/back button is also not needed anymore.

Closes grml/grml#15