### PR TITLE
Start grml-x via .zprofile

### DIFF
--- a/etc/skel/.zprofile
+++ b/etc/skel/.zprofile
@@ -1,0 +1,1 @@
+[[ -z $DISPLAY && -n "$XDG_VTNR" && "$XDG_VTNR" -eq 7 ]] && grml-x


### PR DESCRIPTION
To get rid of our ugly hacks to start X via the bootoption "startx", we
decided to run grml-x on tty7/vt7 which is defined in the
.zprofile-file.

When the bootoption "startx" is given, we switch to tty7 (via
grml-autoconfig) where agetty automatically starts a grml-user
login-(z)-shell and grml-x is started.

Closes grml/grml#20